### PR TITLE
Add '-h' flag to display usage summary

### DIFF
--- a/pg_tmp.1
+++ b/pg_tmp.1
@@ -21,11 +21,11 @@
 .Nd quickly spin up temporary PostgreSQL database
 .Sh SYNOPSIS
 .Nm pg_tmp
-.Op Fl k
-.Op Fl t Op Fl p Ar port
-.Op Fl w Ar timeout
-.Op Fl o Ar extra-options
+.Op Fl kt
 .Op Fl d Ar datadir
+.Op Fl o Ar pgoptions
+.Op Fl p Ar port
+.Op Fl w Ar timeout
 .Sh DESCRIPTION
 The
 .Nm
@@ -39,14 +39,6 @@ The arguments are as follows:
 .Bl -tag -width Ds
 .It Fl k
 Keep the temporary directory after the server is shut down.
-.It Fl w
-Shut down and remove the database after the specified
-.Ar timeout .
-If one or more clients are still connected then
-.Nm
-sleeps and retries again after the same interval.
-A value of 0 will leave the server running indefinitely.
-The default is 60 seconds.
 .It Fl t
 Use a TCP port selected by
 .Xr getsocket 1 .
@@ -54,12 +46,6 @@ A port may be selected using the
 .Fl p
 flag.
 Otherwise the path to a Unix socket is returned.
-.It Fl o
-Specifies extra-options to be passed directly to the
-.Xr postgres 1
-binary.
-These options should usually be surrounded by quotes to ensure that they are
-passed through as a group.
 .It Fl d
 Specify the temporary directory to use.
 May be used with the optional arguments
@@ -70,16 +56,32 @@ and is required for
 If this option is used
 .Nm
 will not initialize a new database for subsequent invocations use.
+.It Fl o
+Specifies options to be passed directly to the
+.Xr postgres 1
+server.
+These options should usually be surrounded by quotes to ensure that they are
+passed through as a group.
+.It Fl p
+TCP port to listen on.
+.It Fl w
+Shut down and remove the database after the specified
+.Ar timeout .
+If one or more clients are still connected then
+.Nm
+sleeps and retries again after the same interval.
+A value of 0 will leave the server running indefinitely.
+The default is 60 seconds.
 .El
 .Sh ENVIRONMENT
 .Bl -tag -width TMPDIR
-.It Ev TMPDIR
-base directory in which to create and run the ephemeral instances of
-.Xr postgres 1
 .It Ev LC_ALL
 Set locale to ensure proper startup on Mac OS.
 If not set the default is
 .Ql C .
+.It Ev TMPDIR
+base directory in which to create and run the ephemeral instances of
+.Xr postgres 1
 .El
 .Sh EXAMPLES
 Create a temporary database and run a query:

--- a/pg_tmp.sh
+++ b/pg_tmp.sh
@@ -16,7 +16,23 @@
 
 usage() {
 	echo >&2 "release: ${release}"
-	echo >&2 "usage: pg_tmp [-k] [-t [-p port]] [-w timeout] [-o extra-options] [-d datadir]"
+	echo >&2 "usage: pg_tmp [-kt] [-d datadir] [-o pgoptions] [-p port] [-w timeout]"
+	if [ -z "$1" ]; then
+		echo >&2 "hint: use -h to display option summary"
+		exit 1
+	fi
+
+	cat <<- HELP
+		summary:
+		    -k            Do not clean up data directory
+		    -t            Use TCP instead of local socket
+		    -d datadir    Specify directory to initialize
+		    -o pgoptions  Run-time parameters for server to use
+		    -p port       Port to listen on
+		    -w timeout    Delay in cleaning up data directory
+		docs:
+		    man pg_tmp
+	HELP
 	exit 1
 }
 
@@ -28,25 +44,26 @@ trap '' HUP
 
 PGVER=$(pg_ctl -V | awk '{print $3}')
 USER_OPTS=""
-getopt > /dev/null ktp:w:o:d: "$@" || usage
+[ $1 == "-h" ] && usage $1
+getopt > /dev/null hktp:w:o:d: "$@" || usage
 while [ $# -gt 0 ]; do
 	case "$1" in
 		-k) KEEP=$1 ;;
 		-t) LISTENTO="127.0.0.1" ;;
-		-p)
-			PGPORT="$2"
-			shift
-			;;
-		-w)
-			TIMEOUT="$2"
+		-d)
+			TD="$2"
 			shift
 			;;
 		-o)
 			USER_OPTS="$2"
 			shift
 			;;
-		-d)
-			TD="$2"
+		-p)
+			PGPORT="$2"
+			shift
+			;;
+		-w)
+			TIMEOUT="$2"
 			shift
 			;;
 		*) CMD=$1 ;;

--- a/test_pg_tmp.rb
+++ b/test_pg_tmp.rb
@@ -49,17 +49,25 @@ puts "\e[32m---\e[39m"
 
 # Option Parsing
 
+try 'Display option summary' do
+  cmd = './pg_tmp -h'
+  out, err, status = Open3.capture3(cmd)
+  eq err.scan('usage:').length, 1
+  eq out.scan('summary:').length, 1
+  eq status.exitstatus, 1
+end
+
 try 'Catch unknown options' do
   cmd = './pg_tmp -t -z'
-  out, _, status = Open3.capture3(cmd)
+  out, err, status = Open3.capture3(cmd)
+  eq err.scan('usage:').length, 1
   eq out.empty?, true
   eq status.exitstatus, 1
 end
 
 try 'Bogus arguments mixed with valid positional' do
   cmd = './pg_tmp -t -z initdb -w 20'
-  out, _, status = Open3.capture3(cmd)
-  eq out.empty?, true
+  _, _, status = Open3.capture3(cmd)
   eq status.exitstatus, 1
 end
 


### PR DESCRIPTION
Also sort arguments

```
$ pg_tmp -x
getopt: unknown option -- x
release: 3.4
usage: pg_tmp [-kt] [-d datadir] [-p port] [-o pgoptions] [-w timeout]
hint: use -h to display option summary
```

```
$ pg_tmp -h
release: 3.4
usage: pg_tmp [-kt] [-d datadir] [-p port] [-o postgres-options] [-w timeout]
summary:
    -k            Do not clean up data directory
    -t            Use TCP instead of local socket
    -d datadir    Specify directory to initialize
    -o pgoptions  Run-time parameters for server to use
    -p port       Port to listen on
    -w timeout    Delay in cleaning up data directory
docs:
    man pg_tmp
```